### PR TITLE
Add an `attrs`-based parser API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,3 +72,4 @@ strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unreachable = True
+plugins = headerparser.mypy

--- a/src/headerparser/__init__.py
+++ b/src/headerparser/__init__.py
@@ -15,6 +15,7 @@ Visit <https://github.com/jwodder/headerparser> or
 
 from .errors import (
     BodyNotAllowedError,
+    DuplicateBodyError,
     DuplicateFieldError,
     Error,
     FieldTypeError,
@@ -29,6 +30,15 @@ from .errors import (
     UnknownFieldError,
 )
 from .normdict import NormalizedDict
+from .parscls import (
+    BodyField,
+    ExtraFields,
+    Field,
+    MultiExtraFields,
+    MultiField,
+    parsable,
+    parse,
+)
 from .parser import HeaderParser
 from .scanner import (
     Scanner,
@@ -39,7 +49,7 @@ from .scanner import (
     scan_stanzas_string,
     scan_string,
 )
-from .types import BOOL, lower, unfold
+from .types import BOOL, decode_bool, decode_value, lower, multidict, unfold
 
 __version__ = "0.5.1"
 __author__ = "John Thorvald Wodder II"
@@ -49,15 +59,21 @@ __url__ = "https://github.com/jwodder/headerparser"
 
 __all__ = [
     "BOOL",
+    "BodyField",
     "BodyNotAllowedError",
+    "DuplicateBodyError",
     "DuplicateFieldError",
     "Error",
-    "HeaderParser",
+    "ExtraFields",
+    "Field",
     "FieldTypeError",
+    "HeaderParser",
     "InvalidChoiceError",
     "MalformedHeaderError",
     "MissingBodyError",
     "MissingFieldError",
+    "MultiExtraFields",
+    "MultiField",
     "NormalizedDict",
     "ParserError",
     "Scanner",
@@ -65,7 +81,12 @@ __all__ = [
     "ScannerError",
     "UnexpectedFoldingError",
     "UnknownFieldError",
+    "decode_bool",
+    "decode_value",
     "lower",
+    "multidict",
+    "parsable",
+    "parse",
     "scan",
     "scan_next_stanza",
     "scan_next_stanza_string",

--- a/src/headerparser/errors.py
+++ b/src/headerparser/errors.py
@@ -54,6 +54,13 @@ class DuplicateFieldError(ParserError):
         return f"Header field {self.name!r} occurs more than once"
 
 
+class DuplicateBodyError(ParserError):
+    """Raised when a body field occurs two or more times in the input"""
+
+    def __str__(self) -> str:
+        return "Body field occurs more than once"
+
+
 class FieldTypeError(ParserError):
     """Raised when a ``type`` callable raises an exception"""
 

--- a/src/headerparser/mypy.py
+++ b/src/headerparser/mypy.py
@@ -1,8 +1,8 @@
-from typing import Any, Type
+from typing import Type
 from mypy.plugin import Plugin
-from mypy.plugins.attrs import attr_attrib_makers, attr_class_makers
+from mypy.plugins.attrs import attr_attrib_makers, attr_define_makers
 
-attr_class_makers.add("headerparser.parscls.parsable")
+attr_define_makers.add("headerparser.parscls.parsable")
 
 attr_attrib_makers.add("headerparser.parscls.Field")
 attr_attrib_makers.add("headerparser.parscls.MultiField")
@@ -15,5 +15,5 @@ class HeaderParserPlugin(Plugin):
     pass
 
 
-def plugin(_version: Any) -> Type[Plugin]:
+def plugin(_version: str) -> Type[Plugin]:
     return HeaderParserPlugin

--- a/src/headerparser/mypy.py
+++ b/src/headerparser/mypy.py
@@ -1,4 +1,4 @@
-from typing import Type
+from __future__ import annotations
 from mypy.plugin import Plugin
 from mypy.plugins.attrs import attr_attrib_makers, attr_define_makers
 
@@ -15,5 +15,5 @@ class HeaderParserPlugin(Plugin):
     pass
 
 
-def plugin(_version: str) -> Type[Plugin]:
+def plugin(_version: str) -> type[Plugin]:
     return HeaderParserPlugin

--- a/src/headerparser/mypy.py
+++ b/src/headerparser/mypy.py
@@ -1,0 +1,19 @@
+from typing import Any, Type
+from mypy.plugin import Plugin
+from mypy.plugins.attrs import attr_attrib_makers, attr_class_makers
+
+attr_class_makers.add("headerparser.parscls.parsable")
+
+attr_attrib_makers.add("headerparser.parscls.Field")
+attr_attrib_makers.add("headerparser.parscls.MultiField")
+attr_attrib_makers.add("headerparser.parscls.ExtraFields")
+attr_attrib_makers.add("headerparser.parscls.MultiExtraFields")
+attr_attrib_makers.add("headerparser.parscls.BodyField")
+
+
+class HeaderParserPlugin(Plugin):
+    pass
+
+
+def plugin(_version: Any) -> Type[Plugin]:
+    return HeaderParserPlugin

--- a/src/headerparser/parscls.py
+++ b/src/headerparser/parscls.py
@@ -1,0 +1,373 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+import attr
+from .errors import (
+    BodyNotAllowedError,
+    DuplicateBodyError,
+    DuplicateFieldError,
+    UnknownFieldError,
+)
+from .scanner import Scanner
+from .types import decode_name
+
+CLS_ATTR_KEY = "__headerparser_spec__"
+METADATA_KEY = "headerparser"
+
+T = TypeVar("T")
+
+FieldDecoder = Callable[[str, str], Any]
+MultiFieldDecoder = Callable[[str, List[str]], Any]
+ExtraFieldsDecoder = Callable[[List[Tuple[str, str]]], Any]
+BodyDecoder = Callable[[str], Any]
+NameDecoder = Callable[[str], str]
+
+
+class InKey(Enum):
+    EXTRA = "extra"
+    BODY = "body"
+
+
+@attr.define
+class BaseFieldProcessor:
+    name: str
+
+    @abstractmethod
+    def process(self, name: str, value: str) -> None:
+        ...
+
+    @abstractmethod
+    def finalize(self, data: Dict[str, Any]) -> None:
+        ...
+
+
+@attr.define
+class FieldProcessor(BaseFieldProcessor):
+    name: str
+    in_key: str
+    decoder: Optional[FieldDecoder]
+    state: Optional[str] = None
+
+    def process(self, _: str, value: str) -> None:
+        if self.state is None:
+            self.state = value
+        else:
+            raise DuplicateFieldError(self.in_key)
+
+    def finalize(self, data: Dict[str, Any]) -> None:
+        if self.state is not None:
+            value: Any = self.state
+            if self.decoder is not None:
+                value = self.decoder(self.name, value)
+            data[self.name] = value
+
+
+@attr.define
+class MultiFieldProcessor(BaseFieldProcessor):
+    name: str
+    in_key: str
+    decoder: Optional[MultiFieldDecoder]
+    state: List[str] = attr.Factory(list)
+
+    def process(self, _: str, value: str) -> None:
+        self.state.append(value)
+
+    def finalize(self, data: Dict[str, Any]) -> None:
+        if self.state:
+            value: Any = self.state
+            if self.decoder is not None:
+                value = self.decoder(self.name, value)
+            data[self.name] = value
+
+
+@attr.define
+class ExtraFieldsProcessor(BaseFieldProcessor):
+    name: str
+    decoder: Optional[ExtraFieldsDecoder]
+    state: List[Tuple[str, str]] = attr.Factory(list)
+    seen: Set[str] = attr.Factory(set)
+
+    def process(self, name: str, value: str) -> None:
+        if name in self.seen:
+            raise DuplicateFieldError(name)
+        self.state.append((name, value))
+        self.seen.add(name)
+
+    def finalize(self, data: Dict[str, Any]) -> None:
+        if self.state:
+            value: Any = self.state
+            if self.decoder is not None:
+                value = self.decoder(value)
+            data[self.name] = value
+
+
+@attr.define
+class MultiExtraFieldsProcessor(BaseFieldProcessor):
+    name: str
+    decoder: Optional[ExtraFieldsDecoder]
+    state: List[Tuple[str, str]] = attr.Factory(list)
+
+    def process(self, name: str, value: str) -> None:
+        self.state.append((name, value))
+
+    def finalize(self, data: Dict[str, Any]) -> None:
+        if self.state:
+            value: Any = self.state
+            if self.decoder is not None:
+                value = self.decoder(value)
+            data[self.name] = value
+
+
+@attr.define
+class BodyProcessor(BaseFieldProcessor):
+    name: str
+    decoder: Optional[BodyDecoder]
+    state: Optional[str] = None
+
+    def process(self, _: str, value: str) -> None:
+        if self.state is not None:
+            raise DuplicateBodyError()
+        self.state = value
+
+    def finalize(self, data: Dict[str, Any]) -> None:
+        if self.state is not None:
+            value: Any = self.state
+            if self.decoder is not None:
+                value = self.decoder(value)
+            data[self.name] = value
+
+
+@attr.define
+class BaseFieldSpec(ABC):
+    name: str
+
+    @property
+    @abstractmethod
+    def in_key(self) -> Union[str, InKey]:
+        ...
+
+    @abstractmethod
+    def get_processor(self) -> BaseFieldProcessor:
+        ...
+
+
+@attr.define
+class FieldSpec(BaseFieldSpec):
+    alias: Optional[str] = None
+    decoder: Optional[FieldDecoder] = None
+
+    @property
+    def in_key(self) -> str:
+        return self.alias if self.alias is not None else self.name
+
+    def get_processor(self) -> BaseFieldProcessor:
+        return FieldProcessor(name=self.name, in_key=self.in_key, decoder=self.decoder)
+
+
+@attr.define
+class MultiFieldSpec(BaseFieldSpec):
+    alias: Optional[str] = None
+    decoder: Optional[MultiFieldDecoder] = None
+
+    @property
+    def in_key(self) -> str:
+        return self.alias if self.alias is not None else self.name
+
+    def get_processor(self) -> BaseFieldProcessor:
+        return MultiFieldProcessor(
+            name=self.name, in_key=self.in_key, decoder=self.decoder
+        )
+
+
+@attr.define
+class ExtraFieldsSpec(BaseFieldSpec):
+    decoder: Optional[ExtraFieldsDecoder] = None
+
+    @property
+    def in_key(self) -> InKey:
+        return InKey.EXTRA
+
+    def get_processor(self) -> BaseFieldProcessor:
+        return ExtraFieldsProcessor(name=self.name, decoder=self.decoder)
+
+
+class MultiExtraFieldsSpec(ExtraFieldsSpec):
+    def get_processor(self) -> BaseFieldProcessor:
+        return MultiExtraFieldsProcessor(name=self.name, decoder=self.decoder)
+
+
+@attr.define
+class BodySpec(BaseFieldSpec):
+    decoder: Optional[BodyDecoder] = None
+
+    @property
+    def in_key(self) -> InKey:
+        return InKey.BODY
+
+    def get_processor(self) -> BaseFieldProcessor:
+        return BodyProcessor(name=self.name, decoder=self.decoder)
+
+
+def Field(
+    *,
+    alias: Optional[str] = None,
+    decoder: Optional[FieldDecoder] = None,
+    **kwargs: Any,
+) -> attr.Attribute:
+    metadata = kwargs.get("metadata")
+    if metadata is None:
+        metadata = {}
+    metadata[METADATA_KEY] = {
+        "alias": alias,
+        "decoder": decoder,
+        "field_type": FieldSpec,
+    }
+    kwargs["metadata"] = metadata
+    return attr.field(**kwargs)
+
+
+def MultiField(
+    *,
+    alias: Optional[str] = None,
+    decoder: Optional[MultiFieldDecoder] = None,
+    **kwargs: Any,
+) -> attr.Attribute:
+    metadata = kwargs.get("metadata")
+    if metadata is None:
+        metadata = {}
+    metadata[METADATA_KEY] = {
+        "alias": alias,
+        "decoder": decoder,
+        "field_type": MultiFieldSpec,
+    }
+    kwargs["metadata"] = metadata
+    return attr.field(**kwargs)
+
+
+def ExtraFields(
+    *, decoder: Optional[ExtraFieldsDecoder] = None, **kwargs: Any
+) -> attr.Attribute:
+    metadata = kwargs.get("metadata")
+    if metadata is None:
+        metadata = {}
+    metadata[METADATA_KEY] = {"decoder": decoder, "field_type": ExtraFieldsSpec}
+    kwargs["metadata"] = metadata
+    return attr.field(**kwargs)
+
+
+def MultiExtraFields(
+    *, decoder: Optional[ExtraFieldsDecoder] = None, **kwargs: Any
+) -> attr.Attribute:
+    metadata = kwargs.get("metadata")
+    if metadata is None:
+        metadata = {}
+    metadata[METADATA_KEY] = {"decoder": decoder, "field_type": MultiExtraFieldsSpec}
+    kwargs["metadata"] = metadata
+    return attr.field(**kwargs)
+
+
+def BodyField(
+    *, decoder: Optional[BodyDecoder] = None, **kwargs: Any
+) -> attr.Attribute:
+    metadata = kwargs.get("metadata")
+    if metadata is None:
+        metadata = {}
+    metadata[METADATA_KEY] = {"decoder": decoder, "field_type": BodySpec}
+    kwargs["metadata"] = metadata
+    return attr.field(**kwargs)
+
+
+def convert_name_decoder(decoder: Optional[NameDecoder]) -> NameDecoder:
+    return decoder if decoder is not None else decode_name
+
+
+def convert_scanner_opts(opts: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    return dict(opts) if opts is not None else {}
+
+
+@attr.define
+class ParsableSpec:
+    name_decoder: NameDecoder = attr.field(converter=convert_name_decoder)
+    scanner_options: Dict[str, Any] = attr.field(converter=convert_scanner_opts)
+    fields: Dict[Union[str, InKey], BaseFieldSpec]
+
+
+def parsable(
+    cls: Type[T] = None,
+    *,
+    name_decoder: Optional[NameDecoder] = None,
+    scanner_options: Optional[Mapping[str, Any]] = None,
+    **kwargs: Any,
+) -> Type[T]:
+    cls = attr.define(**kwargs)(cls)
+    fields: Dict[Union[str, InKey], BaseFieldSpec] = {}
+    for field in attr.fields(cls):
+        metadata = (field.metadata or {}).get(METADATA_KEY, {})
+        assert isinstance(metadata, dict)
+        metadata = metadata.copy()
+        ftype = metadata.pop("field_type", FieldSpec)
+        assert issubclass(ftype, BaseFieldSpec)
+        spec = ftype(name=field.name, **metadata)
+        if spec.in_key in fields:
+            if isinstance(spec.in_key, str):
+                raise ValueError(
+                    f"Multiple fields for header name {spec.in_key!r} registered"
+                )
+            elif spec.in_key is InKey.EXTRA:
+                raise ValueError("Multiple extra fields registered")
+            elif spec.in_key is InKey.BODY:
+                raise ValueError("Multiple body fields registered")
+            else:
+                raise AssertionError(  # pragma: no cover
+                    f"Unhandled InKey {spec.in_key!r}"
+                )
+        fields[spec.in_key] = spec
+    p = ParsableSpec(
+        name_decoder=name_decoder,
+        scanner_options=scanner_options,
+        fields=fields,
+    )
+    setattr(cls, CLS_ATTR_KEY, p)
+    return cls
+
+
+def parse(cls: Type[T], data: Union[str, Iterable[str]]) -> T:
+    p = getattr(cls, CLS_ATTR_KEY, None)
+    if not isinstance(p, ParsableSpec):
+        raise TypeError(f"{type(p).__name__} is not a parsable class")
+    sc = Scanner(data, **p.scanner_options)
+    processors = {k: v.get_processor() for k, v in p.fields.items()}
+    for (name, value) in sc.scan():
+        if name is not None:
+            name = p.name_decoder(name)
+            try:
+                proc = processors[name]
+            except KeyError:
+                try:
+                    proc = processors[InKey.EXTRA]
+                except KeyError:
+                    raise UnknownFieldError(name)
+        else:
+            name = "<BODY>"
+            try:
+                proc = processors[InKey.BODY]
+            except KeyError:
+                raise BodyNotAllowedError()
+        proc.process(name, value)
+    data: Dict[str, Any] = {}
+    for proc in processors.values():
+        proc.finalize(data)
+    return cls(**data)

--- a/src/headerparser/types.py
+++ b/src/headerparser/types.py
@@ -1,5 +1,9 @@
 import re
-from typing import Any
+from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
 
 TRUTHY = {"yes", "y", "on", "true", "1"}
 FALSEY = {"no", "n", "off", "false", "0"}
@@ -55,3 +59,25 @@ def unfold(s: str) -> str:
     :rtype: string
     """
     return re.sub(r"[ \t]*[\r\n][ \t\r\n]*", " ", s).strip(" ")
+
+
+def decode_bool(_: str, value: str) -> bool:
+    return BOOL(value)
+
+
+def decode_value(func: Callable[[str], T]) -> Callable[[str, str], T]:
+    def decoder(_: str, value: str) -> bool:
+        return func(value)
+
+    return decoder
+
+
+def multidict(values: Iterable[Tuple[K, V]]) -> Dict[K, List[V]]:
+    data: Dict[K, List[V]] = {}
+    for k, v in values:
+        data.setdefault(k, []).append(v)
+    return data
+
+
+def decode_name(name: str) -> str:
+    return re.sub(r"\W", "_", name.lower())

--- a/src/headerparser/types.py
+++ b/src/headerparser/types.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+from collections.abc import Callable, Iterable
 import re
-from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -72,8 +74,8 @@ def decode_value(func: Callable[[str], T]) -> Callable[[str, str], T]:
     return decoder
 
 
-def multidict(values: Iterable[Tuple[K, V]]) -> Dict[K, List[V]]:
-    data: Dict[K, List[V]] = {}
+def multidict(values: Iterable[tuple[K, V]]) -> dict[K, list[V]]:
+    data: dict[K, list[V]] = {}
     for k, v in values:
         data.setdefault(k, []).append(v)
     return data

--- a/src/headerparser/types.py
+++ b/src/headerparser/types.py
@@ -66,7 +66,7 @@ def decode_bool(_: str, value: str) -> bool:
 
 
 def decode_value(func: Callable[[str], T]) -> Callable[[str, str], T]:
-    def decoder(_: str, value: str) -> bool:
+    def decoder(_: str, value: str) -> T:
         return func(value)
 
     return decoder

--- a/test/test_parsable/test_parsable.py
+++ b/test/test_parsable/test_parsable.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, Tuple, Type
+from __future__ import annotations
+from typing import Any, Optional
 import pytest
 from headerparser import (
     BodyField,
@@ -22,8 +23,8 @@ class Simple:
     simple: str
     optional: Optional[str] = None
     aliased: Optional[str] = Field(alias="alias", default=None)
-    multi: List[str] = MultiField(factory=list)
-    extra: List[Tuple[str, str]] = ExtraFields(factory=list)
+    multi: list[str] = MultiField(factory=list)
+    extra: list[tuple[str, str]] = ExtraFields(factory=list)
     body: Optional[str] = BodyField(default=None)
 
 
@@ -31,7 +32,7 @@ class Simple:
 class MultiExtra:
     foo: int = Field(decoder=decode_value(int))
     bar: bool = Field(decoder=decode_bool)
-    extra: Dict[str, List[str]] = MultiExtraFields(decoder=multidict, factory=dict)
+    extra: dict[str, list[str]] = MultiExtraFields(decoder=multidict, factory=dict)
 
 
 @parsable
@@ -137,7 +138,7 @@ def test_parse(cls: type, data: str, obj: Any) -> None:
     ],
 )
 def test_parse_error(
-    cls: type, data: str, exc_type: Type[Exception], exc_match: str
+    cls: type, data: str, exc_type: type[Exception], exc_match: str
 ) -> None:
     with pytest.raises(exc_type, match=exc_match):
         parse(cls, data)

--- a/test/test_parsable/test_parsable.py
+++ b/test/test_parsable/test_parsable.py
@@ -1,0 +1,144 @@
+from typing import Any, Dict, List, Optional, Tuple, Type
+import pytest
+from headerparser import (
+    BodyField,
+    BodyNotAllowedError,
+    DuplicateFieldError,
+    ExtraFields,
+    Field,
+    MultiExtraFields,
+    MultiField,
+    UnknownFieldError,
+    decode_bool,
+    decode_value,
+    multidict,
+    parsable,
+    parse,
+)
+
+
+@parsable
+class Simple:
+    simple: str
+    optional: Optional[str] = None
+    aliased: Optional[str] = Field(alias="alias", default=None)
+    multi: List[str] = MultiField()
+    extra: List[Tuple[str, str]] = ExtraFields()
+    body: Optional[str] = BodyField()
+
+
+@parsable
+class MultiExtra:
+    foo: int = Field(decoder=decode_value(int))
+    bar: bool = Field(decoder=decode_bool)
+    extra: Dict[str, List[str]] = MultiExtraFields(decoder=multidict)
+
+
+@parsable
+class CrissCross:
+    one: str = Field(alias="two")
+    two: str = Field(alias="one")
+
+
+@pytest.mark.parametrize(
+    "data,obj",
+    [
+        (
+            Simple,
+            "Simple: foobar\n",
+            Simple(
+                simple="foobar",
+                optional=None,
+                aliased=None,
+                multi=[],
+                extra=[],
+                body=None,
+            ),
+        ),
+        (
+            Simple,
+            "Simple: foobar\nOptional: present\nAlias: unknown\nAliased: extra\n"
+            "Extra: overflow\nMulti: one\nMulti: two\nHyphen-Ated: Hyphen-Ated\n"
+            "\nThis is the body.\n",
+            Simple(
+                simple="foobar",
+                optional="present",
+                aliased="unknown",
+                multi=["one", "two"],
+                extra=[
+                    ("aliased", "extra"),
+                    ("extra", "overflow"),
+                    ("hyphen-ated", "Hyphen-Ated"),
+                ],
+                body="This is the body.\n",
+            ),
+        ),
+        (
+            MultiExtra,
+            "Foo: 42\nBar: true\nExtra: one\nExtra: two\nOther: stuff\n",
+            MultiExtra(
+                foo=42,
+                bar=True,
+                extra={"extra": ["one", "two"], "other": ["stuff"]},
+            ),
+        ),
+        (MultiExtra, "Bar: no\nFoo: 23\n", MultiExtra(foo=23, bar=False, extra={})),
+        (
+            CrissCross,
+            "ONE: apple\nTWO: banana\n",
+            CrissCross(one="banana", two="apple"),
+        ),
+    ],
+)
+def test_parse(cls: type, data: str, obj: Any) -> None:
+    assert parse(cls, data) == obj
+
+
+@pytest.mark.parametrize(
+    "data,exc_type,exc_str",
+    [
+        (
+            Simple,
+            "Simple: one\nSimple: two\n",
+            DuplicateFieldError,
+            "Header field 'simple' occurs more than once",
+        ),
+        (
+            Simple,
+            "Simple: foobar\nExtra: one\nExtra: two\n",
+            DuplicateFieldError,
+            "Header field 'extra' occurs more than once",
+        ),
+        (
+            Simple,
+            "",
+            TypeError,
+            "__init__() missing 1 required positional argument: 'simple'",
+        ),
+        (
+            MultiExtra,
+            "Foo: forty-two\n",
+            ValueError,
+            "invalid literal for int() with base 10: 'forty-two'",
+        ),
+        (MultiExtra, "Bar: maybe\n", ValueError, "invalid boolean: 'maybe'"),
+        (
+            MultiExtra,
+            "Some: field\n\nSome: body\n",
+            BodyNotAllowedError,
+            "Message body is present but not allowed",
+        ),
+        (
+            CrissCross,
+            "Unknown: field\n",
+            UnknownFieldError,
+            "Unknown header field 'unknown'",
+        ),
+    ],
+)
+def test_parse_error(
+    cls: type, data: str, exc_type: Type[Exception], exc_str: str
+) -> None:
+    with pytest.raises(exc_type) as excinfo:
+        parse(cls, data)
+    assert str(excinfo.value) == exc_str

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,10 @@ source =
 [coverage:report]
 precision = 2
 show_missing = True
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+    \.\.\.
 
 [flake8]
 doctests = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,10 @@ deps =
     pytest-mock
 commands =
     coverage erase
-    coverage run -m pytest {posargs} --doctest-modules --pyargs headerparser
+    # --doctest-ignore-import-errors is needed in order to not collect
+    # headerparser.mypy, which requires mypy to be installed, which is not an
+    # option on PyPy3.[67]
+    coverage run -m pytest {posargs} --doctest-modules --pyargs --doctest-ignore-import-errors headerparser
     coverage run -m pytest {posargs} test README.rst docs/index.rst
     coverage combine
     coverage report


### PR DESCRIPTION
Closes #52.

To do:

- [ ] Ensure that subclassing works!
    - Subclasses of parsable need to be decorated with `@parsable` as well in order to guarantee that parsing them works
    - A subclass of a parsable that is also decorated with `@parsable` should fall back to the parents' `name_decoder` and other `@parsable`-specific params if the subclass doesn't specify them
        - How should this work with multiple inheritance?
        - Maybe don't inherit `@parsable` params?
- [ ] Use `typing.assert_type()` in tests?
- [ ] Write docs
    - [ ] Document mypy plugin
- [ ] Update changelog
- [ ] Rewrite long description
- [ ] Change the package's short description to no longer mention the "argparse-like-ness"
- [ ] Deprecate the old argparse-like parser